### PR TITLE
Fixed the top command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Then, you can visit the following links:
   - http://localhost:4000
   - http://localhost:4000/load
   - http://localhost:4000/services
+  - http://localhost:4000/top
 
 ## Demo
 

--- a/example_system/lib/example_system_web/top/dashboard.ex
+++ b/example_system/lib/example_system_web/top/dashboard.ex
@@ -7,10 +7,10 @@ defmodule ExampleSystemWeb.Top.Dashboard do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("process_info", pid_str, socket),
+  def handle_event("process_info", %{ "pid" => pid_str}, socket),
     do: {:noreply, assign(socket, :output, process_info(:erlang.list_to_pid('<#{pid_str}>')))}
 
-  def handle_event("process_kill", pid_str, socket) do
+  def handle_event("process_kill", %{ "pid" => pid_str}, socket) do
     Process.exit(:erlang.list_to_pid('<#{pid_str}>'), :kill)
     {:noreply, socket}
   end

--- a/example_system/lib/example_system_web/top/dashboard.html.leex
+++ b/example_system/lib/example_system_web/top/dashboard.html.leex
@@ -7,8 +7,8 @@
         <div class="header">CPU</div>
         <%= Enum.map(@top, fn process -> %>
             <div class="pid">
-              <a href="#" phx-click="process_info" phx-value="<%= stringify_pid(process.pid) %>">info</a>
-              <a href="#" phx-click="process_kill" phx-value="<%= stringify_pid(process.pid) %>">kill</a>
+              <a href="#" phx-click="process_info" phx-value-pid="<%= stringify_pid(process.pid) %>">info</a>
+              <a href="#" phx-click="process_kill" phx-value-pid="<%= stringify_pid(process.pid) %>">kill</a>
             </div>
             <%= stringify_pid(process.pid) %>
           <div class="cpu"><%= process.cpu %>%</div>


### PR DESCRIPTION
The top command was broken due to a minor syntax change.
This fixes it so now works as the original demo.